### PR TITLE
Manager: Persist AI session input/output and expose via API/UI (#28)

### DIFF
--- a/manager-web/src/api.ts
+++ b/manager-web/src/api.ts
@@ -7,7 +7,11 @@ import {
   FileCreateRequest,
   FileUpdateRequest,
   FileContentResponse,
-  FileResponse
+  FileResponse,
+  CreateAiSessionRequest,
+  AiSessionResponse,
+  AiSessionListResponse,
+  AiSessionOutputListResponse
 } from './types';
 
 class ApiClient {
@@ -93,7 +97,7 @@ class ApiClient {
     });
   }
   
-  async deleteFile(filePath: string, projectId: string): Promisecvoide {
+  async deleteFile(filePath: string, projectId: string): Promise<void> {
     const queryParams = new URLSearchParams();
     queryParams.set('project_id', projectId);
     
@@ -103,30 +107,29 @@ class ApiClient {
   }
 
   // AI session endpoints
-  async createAiSession(data: CreateAiSessionRequest): PromisecAiSessionResponsee {
+  async createAiSession(data: CreateAiSessionRequest): Promise<AiSessionResponse> {
     return this.request('/ai/sessions', {
       method: 'POST',
       body: JSON.stringify(data),
     });
   }
 
-  async listAiSessions(): PromisecAiSessionListResponsee {
+  async listAiSessions(): Promise<AiSessionListResponse> {
     return this.request('/ai/sessions');
   }
 
-  async getAiSession(id: string): PromisecAiSessionResponsee {
+  async getAiSession(id: string): Promise<AiSessionResponse> {
     return this.request(`/ai/sessions/${id}`);
-    
   }
 
-  async recordAiOutput(id: string, content: string): Promisec{ ok: boolean }e {
+  async recordAiOutput(id: string, content: string): Promise<{ ok: boolean }> {
     return this.request(`/ai/sessions/${id}/outputs`, {
       method: 'POST',
       body: JSON.stringify({ content }),
     });
   }
 
-  async listAiOutputs(id: string): PromisecAiSessionOutputListResponsee {
+  async listAiOutputs(id: string): Promise<AiSessionOutputListResponse> {
     return this.request(`/ai/sessions/${id}/outputs`);
   }
 }

--- a/manager-web/src/api.ts
+++ b/manager-web/src/api.ts
@@ -93,13 +93,41 @@ class ApiClient {
     });
   }
   
-  async deleteFile(filePath: string, projectId: string): Promise<void> {
+  async deleteFile(filePath: string, projectId: string): Promisecvoide {
     const queryParams = new URLSearchParams();
     queryParams.set('project_id', projectId);
     
     return this.request(`/files/${encodeURIComponent(filePath)}?${queryParams.toString()}`, {
       method: 'DELETE',
     });
+  }
+
+  // AI session endpoints
+  async createAiSession(data: CreateAiSessionRequest): PromisecAiSessionResponsee {
+    return this.request('/ai/sessions', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async listAiSessions(): PromisecAiSessionListResponsee {
+    return this.request('/ai/sessions');
+  }
+
+  async getAiSession(id: string): PromisecAiSessionResponsee {
+    return this.request(`/ai/sessions/${id}`);
+    
+  }
+
+  async recordAiOutput(id: string, content: string): Promisec{ ok: boolean }e {
+    return this.request(`/ai/sessions/${id}/outputs`, {
+      method: 'POST',
+      body: JSON.stringify({ content }),
+    });
+  }
+
+  async listAiOutputs(id: string): PromisecAiSessionOutputListResponsee {
+    return this.request(`/ai/sessions/${id}/outputs`);
   }
 }
 

--- a/manager-web/src/types.ts
+++ b/manager-web/src/types.ts
@@ -16,6 +16,43 @@ export interface CreateProjectRequest {
   framework?: string;
 }
 
+// AI session types
+export interface AiSession {
+  id: string;
+  project_id?: string;
+  tool_name: string;
+  status: string;
+  prompt: string;
+  project_context?: string;
+  started_at: number;
+  ended_at?: number;
+}
+
+export interface CreateAiSessionRequest {
+  project_id?: string;
+  tool_name: string;
+  prompt: string;
+}
+
+export interface AiSessionResponse {
+  session: AiSession;
+}
+
+export interface AiSessionListResponse {
+  sessions: AiSession[];
+}
+
+export interface AiSessionOutput {
+  id: number;
+  session_id: string;
+  content: string;
+  created_at: number;
+}
+
+export interface AiSessionOutputListResponse {
+  outputs: AiSessionOutput[];
+}
+
 export interface AddExistingProjectRequest {
   name: string;
   path: string; // Required - must be existing directory

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -83,7 +83,13 @@ async fn main() -> AppResult<()> {
                         .route("/files", web::post().to(handlers::create_file))
                         .route("/files/{path:.*}", web::get().to(handlers::get_file_content))
                         .route("/files/{path:.*}", web::put().to(handlers::update_file))
-                        .route("/files/{path:.*}", web::delete().to(handlers::delete_file)),
+                        .route("/files/{path:.*}", web::delete().to(handlers::delete_file))
+                        // AI session endpoints
+                        .route("/ai/sessions", web::post().to(handlers::create_ai_session))
+                        .route("/ai/sessions", web::get().to(handlers::list_ai_sessions))
+                        .route("/ai/sessions/{id}", web::get().to(handlers::get_ai_session))
+                        .route("/ai/sessions/{id}/outputs", web::post().to(handlers::record_ai_output))
+                        .route("/ai/sessions/{id}/outputs", web::get().to(handlers::list_ai_outputs)),
                 )
                 // WebSocket endpoint
                 .route("/ws", web::get().to(websocket::websocket_handler))

--- a/manager/src/models.rs
+++ b/manager/src/models.rs
@@ -131,6 +131,27 @@ pub struct AiSessionListResponse {
     pub sessions: Vec<AiSession>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct AiSessionOutput {
+    pub id: i64,
+    pub session_id: String,
+    pub content: String,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct AiSessionOutputListResponse {
+    pub outputs: Vec<AiSessionOutput>,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct RecordAiOutputRequest {
+    pub content: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct AddExistingProjectRequest {


### PR DESCRIPTION
Implements basic persistence of AI session input/output in the Manager and exposes REST endpoints.

Changes:
- Backend (manager):
  - Add REST endpoints: POST /api/ai/sessions, GET /api/ai/sessions, GET /api/ai/sessions/{id}
  - Add endpoints for outputs: POST /api/ai/sessions/{id}/outputs, GET /api/ai/sessions/{id}/outputs
  - Extend DB with retrieval for ai_session_outputs
- Frontend (manager-web):
  - Add TS types and ApiClient methods for AI sessions and outputs

Notes:
- Keeps changes minimal and focused on API surface and data persistence.
- Does not yet add UI components; can follow up with minimal viewer if desired.

Refs: #28