### PR TITLE
fix: Use proper Astro image import for CloudFlare Pages deployment

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import Button from '../components/UI/Button.astro';
 import Card from '../components/UI/Card.astro';
+import screenshotImage from '../assets/nocodo_AI_Session_Details_Redesigned_26_August_2025.png';
 
 const solutionPoints = [
   {
@@ -101,7 +102,7 @@ const solutionPoints = [
         <div class="max-w-5xl mx-auto">
           <div class="relative">
             <img 
-              src="/src/assets/nocodo_AI_Session_Details_Redesigned_26_August_2025.png" 
+              src={screenshotImage.src} 
               alt="nocodo AI Session Details - Live output from AI coding session showing project analysis and development workflow"
               class="w-full rounded-lg shadow-2xl border border-gray-200"
             />


### PR DESCRIPTION
- Import screenshot image using Astro's image import syntax
- Replace direct path with imported image.src reference
- Ensures image is properly processed and included in static build
- Fixes image not showing on CloudFlare Pages deployment

🤖 Generated with [Claude Code](https://claude.ai/code)