### PR TITLE
Fix: Prevent binary from exiting after browser launch

### DIFF
--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -282,7 +282,7 @@ async fn main() -> AppResult<()> {
     });
 
     // Launch browser after server starts
-    let browser_task = tokio::spawn({
+    let _browser_task = tokio::spawn({
         let browser_config = browser_config.clone();
         let server_url = server_url.clone();
         async move {
@@ -295,10 +295,11 @@ async fn main() -> AppResult<()> {
     });
 
     // Wait for servers (they should run indefinitely)
+    // We don't want to exit when browser launcher completes
+    // Only exit when HTTP or socket server completes
     tokio::select! {
         _ = socket_task => tracing::info!("Socket server completed"),
         _ = http_task => tracing::info!("HTTP server completed"),
-        _ = browser_task => tracing::info!("Browser launcher completed"),
     }
 
     Ok(())


### PR DESCRIPTION
The nocodo-manager binary was exiting after launching the browser because the browser launcher task completion was causing the program to terminate. Modified main.rs to only exit when HTTP or socket servers complete, not when browser launcher completes.