### PR TITLE
Fix LLM agent tool system not processing tool call responses

### DIFF
--- a/manager/src/database.rs
+++ b/manager/src/database.rs
@@ -1385,7 +1385,7 @@ impl Database {
 
     pub fn get_llm_agent_session_by_work_id(&self, work_id: &str) -> AppResult<LlmAgentSession> {
         let sessions = self.get_llm_agent_sessions_by_work(work_id)?;
-        
+
         match sessions.first() {
             Some(session) => Ok(session.clone()),
             None => Err(AppError::NotFound(format!(

--- a/manager/src/handlers.rs
+++ b/manager/src/handlers.rs
@@ -948,7 +948,7 @@ pub async fn create_ai_session(
             let llm_session = llm_agent
                 .create_session(
                     work_id.clone(),
-                    "grok".to_string(),      // Default provider
+                    "grok".to_string(),             // Default provider
                     "grok-code-fast-1".to_string(), // Default model
                     session.project_context.clone(),
                 )

--- a/manager/src/llm_client.rs
+++ b/manager/src/llm_client.rs
@@ -172,7 +172,7 @@ impl LlmClient for OpenAiCompatibleClient {
                 .text()
                 .await
                 .unwrap_or_else(|_| "Unknown error".to_string());
-            
+
             tracing::error!(
                 provider = %self.config.provider,
                 model = %request.model,
@@ -181,7 +181,7 @@ impl LlmClient for OpenAiCompatibleClient {
                 error = %error_text,
                 "LLM API request failed"
             );
-            
+
             return Err(anyhow::anyhow!(
                 "LLM API error: {} - {}",
                 status,
@@ -190,7 +190,7 @@ impl LlmClient for OpenAiCompatibleClient {
         }
 
         let completion: LlmCompletionResponse = response.json().await?;
-        
+
         tracing::info!(
             provider = %self.config.provider,
             model = %request.model,


### PR DESCRIPTION
## Summary
- Fixed issue #105 where LLM agent tool system shows tool call JSON but doesn't process tool execution results
- Added missing system prompt to follow-up LLM requests after tool execution
- Enhanced system prompt with explicit instructions for handling tool results

## Root Cause
The `follow_up_with_llm()` method was missing the tool system prompt that instructs the LLM on how to handle tool execution results. This caused the LLM to receive tool results without proper context on how to interpret and respond to them.

## Changes Made
- **llm_agent.rs**: Added system prompt to `follow_up_with_llm()` method (lines 452-457)
- **llm_agent.rs**: Enhanced `create_tool_system_prompt()` with explicit tool result handling instructions
- **llm_agent.rs**: Added test coverage for system prompt functionality
- Applied code formatting fixes across affected files

## Test Plan
- [x] Unit test verifies system prompt contains proper tool handling instructions
- [x] All existing tests pass
- [x] Code formatting and linting checks pass
- [ ] Manual testing: Create LLM agent session, trigger tool calls, verify natural language responses

## Technical Details
The fix ensures that when tools are executed and their results are passed back to the LLM, the conversation includes the system prompt containing:
1. Tool usage instructions
2. Explicit guidance on processing tool results (messages with role "tool")
3. Instructions to provide natural language responses based on tool outputs

🤖 Generated with [Claude Code](https://claude.ai/code)